### PR TITLE
Fix Windows issue by removing reuse_port option

### DIFF
--- a/aiovoip/peers.py
+++ b/aiovoip/peers.py
@@ -317,7 +317,6 @@ class UDPConnector(BaseConnector):
                 lambda: UDP(app=self._app, loop=self._loop),
                 local_addr=local_addr,
                 remote_addr=peer_addr,
-                reuse_port=True,
             )
             local_addr = transport.get_extra_info('sockname')
             self._protocols[(peer_addr, local_addr)] = proto
@@ -336,7 +335,6 @@ class UDPConnector(BaseConnector):
                 lambda: UDP(app=self._app, loop=self._loop),
                 sock=sock,
                 local_addr=local_addr,
-                reuse_port=True,
             )
             proto_addr = proto.transport.get_extra_info('sockname')
             if sock:


### PR DESCRIPTION
Python version :  Python 3.12.6 
OS: Windows  11 x64

Since this parameter allows multiple processes to bind to the same port in parallel, but we only have a single process in this case, and considering that it breaks compatibility with Windows, it is advisable to apply this fix.

![Failed](https://github.com/user-attachments/assets/04371689-5417-4ad0-80fd-220bbc3572db)

